### PR TITLE
create my car with detailId only

### DIFF
--- a/src/car/car.controller.ts
+++ b/src/car/car.controller.ts
@@ -52,43 +52,14 @@ export class CarController {
   }
 
   @Post()
-  @UseInterceptors(FilesInterceptor('files', 1))
-  async createCarInfo(
-    @UploadedFiles() files: Express.Multer.File[],
+  async createMyCar(
+    @Body('detailId') detailId: number,
     @Headers('user-token') token: string,
-    @Req() request,
-    @Body() createCarInfoDto: CreateCarInfoDto,
-  ): Promise<{ id: number; status: string }> {
-    const { detailId, brandId, modelId, nickName } = createCarInfoDto;
-
+  ) {
     const user = await this.userService.findUserbyToken(token);
-    const brand = await this.carListService.findBrand(brandId);
-    const model = await this.carListService.findModel(modelId);
-    const detail = await this.carListService.findDetail(detailId);
-    const recordType: RecordType = 'car';
-    const carInfo = await this.carService.createCarInfo(
-      brand,
-      model,
-      detail,
-      user,
-      nickName,
-    );
-
-    if (files) {
-      const images = await this.imageService.uploadImage(files, request);
-
-      const car = await this.carService.findCarInfoById(carInfo['id'], user);
-
-      await this.imageService.saveImage(
-        images,
-        car['id'],
-        recordType,
-        car['id'],
-      );
-    }
-
+    const result = await this.carService.createMyCar(detailId, user);
     return {
-      id: carInfo.id,
+      id: result.id,
       status: '저장완료',
     };
   }

--- a/src/car/carlist.service.ts
+++ b/src/car/carlist.service.ts
@@ -28,6 +28,7 @@ export class CarListService {
     });
   }
 
+  // API: 브랜드 객체를 넘겨받아 해당 브랜드안 모델들을 조회한다.
   async findModels(brand: Brand) {
     return await this.modelRepository
       .createQueryBuilder('model')

--- a/src/car/entities/car.entity.ts
+++ b/src/car/entities/car.entity.ts
@@ -23,34 +23,34 @@ export class Car {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
-  nickName: string;
+  @Column({ nullable: true })
+  nickName?: string;
 
   @ManyToOne(() => Brand, (brand) => brand.car, {
     cascade: true,
     onDelete: 'CASCADE',
-    lazy: true
+    lazy: true,
   })
   brand: Brand;
 
   @ManyToOne(() => Model, (model) => model.car, {
     cascade: true,
     onDelete: 'CASCADE',
-    lazy: true
+    lazy: true,
   })
   model: Model;
 
   @ManyToOne(() => Detail, (detail) => detail.car, {
     cascade: true,
     onDelete: 'CASCADE',
-    lazy: true
+    lazy: true,
   })
   detail: Detail;
 
   @ManyToOne(() => User, (user) => user.car, {
     cascade: true,
     onDelete: 'CASCADE',
-    lazy: true
+    lazy: true,
   })
   user: User;
 
@@ -78,18 +78,11 @@ export class Car {
   @DeleteDateColumn()
   deletedAt: Date;
 
-  static createCarInfo(
-    brand: Brand,
-    model: Model,
-    detail: Detail,
-    nickName: string,
-    user: User,
-  ){
+  static createCarInfo(brand: Brand, model: Model, detail: Detail, user: User) {
     const car = new Car();
     car.brand = brand;
     car.model = model;
     car.detail = detail;
-    car.nickName = nickName;
     car.user = user;
     return car;
   }

--- a/src/record/record.module.ts
+++ b/src/record/record.module.ts
@@ -22,6 +22,9 @@ import { MaintenanceController } from './maintenance/maintenance.controller';
 import { MaintenancePart } from './entities/maintenacnepart.entity';
 import { MaintenanceTime } from './entities/maintenancetime.entity';
 import { RecordController } from './record.controller';
+import { Detail } from 'src/car/entities/detail.entity';
+import { Brand } from 'src/car/entities/brand.entity';
+import { Model } from 'src/car/entities/model.entity';
 @Module({
   imports: [
     TypeOrmModule.forFeature([
@@ -32,6 +35,9 @@ import { RecordController } from './record.controller';
       User,
       Device,
       Image,
+      Detail,
+      Brand,
+      Model,
       Car,
       MaintenancePart,
       MaintenanceTime,


### PR DESCRIPTION
기획수정에 따른 create api 변경. 
기존에는 내차 생성시 이미지업로드 및 nickname, brandId, modelId, detailId 모두 받아 create api를 작동시켰다면 이제는 detailId하나만 받아 생성하게됨. 이미지업로드 하지않고 nickname또한 받지않음

- 기존 brandId, modelId, detailId, nickname을 받아 내차 생성 api를 detailId 만 받아 생성하는 api로 변경
- nickname을 생성시 필수값으로 받았다면 이제 nullable로 변경 => 차량 등록 flow가 변경됨에 따라 달리 nickname을 받는 step이 사라짐

- 내차 생성시 받았던 image역시 받지않음(생성시 이미지 업로드 하지않는 기획으로 바뀜)